### PR TITLE
Add email field to registration form

### DIFF
--- a/templates/register.html
+++ b/templates/register.html
@@ -21,6 +21,14 @@
             </div>
 
             <div class="form-group">
+                <label for="email">
+                    <span class="icon">📧</span>
+                    Correo electrónico (requerido)
+                </label>
+                {{ form.email(class="auth-input", placeholder="Tu correo electrónico") }}
+            </div>
+
+            <div class="form-group">
                 <label for="password">
                     <span class="icon">🔒</span>
                     Contraseña


### PR DESCRIPTION
## Summary
- Add required email input to registration template so RegisterForm validation succeeds

## Testing
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68b0159f093c83279fcc7353274cda89