### PR TITLE
Add script to promote a user to admin

### DIFF
--- a/promote_admin.py
+++ b/promote_admin.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Promote a user to administrator.
+
+Usage:
+    python promote_admin.py <username>
+"""
+
+import sys
+
+from app import app, db
+from app.models import User
+
+
+def promote(username: str) -> None:
+    """Promote the specified user to admin if they exist."""
+    with app.app_context():
+        user = User.query.filter_by(username=username).first()
+        if user:
+            user.is_admin = True
+            db.session.commit()
+            print(f"User '{username}' promoted to admin.")
+        else:
+            print(f"Error: User '{username}' not found.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python promote_admin.py <username>")
+        sys.exit(1)
+    promote(sys.argv[1])


### PR DESCRIPTION
## Summary
- Add `promote_admin.py` utility to elevate a user's `is_admin` flag via CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app'; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68b018f8218c8327aa8df5b4599892ac