### PR TITLE
Fix admin promotion script app initialization

### DIFF
--- a/promote_admin.py
+++ b/promote_admin.py
@@ -7,8 +7,11 @@ Usage:
 
 import sys
 
-from app import app, db
+from app import create_app
+from app.extensions import db
 from app.models import User
+
+app = create_app()
 
 
 def promote(username: str) -> None:


### PR DESCRIPTION
## Summary
- Import the app factory and extensions in `promote_admin.py`
- Instantiate the Flask app with `create_app()` for the promote script

## Testing
- `python promote_admin.py testuser` *(fails: sqlite3.OperationalError: unable to open database file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'requests'; etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68b01b67a59883278308d6a21629857f