### PR TITLE
Use inventory template for admin toys page

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -570,7 +570,7 @@ def toys_page():
     toy_form = ToyForm()
     toys = Toy.query.filter_by(is_active=True).order_by(Toy.created_at.desc()).all()
 
-    return render_template('admin_toys.html', toy_form=toy_form, toys=toys)
+    return render_template('admin/inventory.html', toy_form=toy_form, toys=toys)
 
 # NUEVA IMPLEMENTACIÓN: Edición de juguetes simple y robusta
 @admin_bp.route('/toy_edit_new/<int:toy_id>', methods=['POST'])


### PR DESCRIPTION
## Summary
- Render admin inventory template for `/admin/toys`

## Testing
- `python - <<'PY' ...` (verifies `/admin/toys` returns inventory page)
- `pytest tests/unit -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_b_68b01e15e31c832792114f21d7076d65