### PR TITLE
Add admin toys add endpoint

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -365,6 +365,7 @@ def toggle_user(user_id):
     return redirect(url_for('admin.all_users'))
 
 
+@admin_bp.route('/toys/add', methods=['POST'])
 @admin_bp.route('/add_toy', methods=['GET', 'POST'])
 @login_required
 @moderate_rate_limit(message="⚠️ Demasiados intentos de agregar juguetes. Espera un momento.")
@@ -420,7 +421,7 @@ def add_toy():
             for error in errors:
                 flash(f'Error en {field}: {error}', 'error')
     
-    return redirect(url_for('admin.dashboard'))
+    return redirect(url_for('admin.toys_page'))
 
 @admin_bp.route('/edit_toy/<int:toy_id>', methods=['GET', 'POST'])
 @login_required

--- a/tests/unit/test_admin_add_toy_route.py
+++ b/tests/unit/test_admin_add_toy_route.py
@@ -1,0 +1,62 @@
+import io
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from app import create_app, db
+from app.models import User, Toy
+from app.config import Config
+
+
+class TestConfig(Config):
+    TESTING = True
+    WTF_CSRF_ENABLED = False
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    SECRET_KEY = 'test'
+    LOGIN_DISABLED = False  # We'll simulate login
+
+
+@pytest.fixture()
+def app():
+    app = create_app(TestConfig)
+    with app.app_context():
+        db.create_all()
+        # create admin user
+        admin = User(username='admin', email='admin@example.com', is_admin=True)
+        admin.set_password('password')
+        db.session.add(admin)
+        db.session.commit()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def login_as_admin(client, app):
+    with client.session_transaction() as sess:
+        sess['_user_id'] = '1'
+        sess['_fresh'] = True
+
+
+def test_add_toy_redirects_to_inventory(client, app):
+    login_as_admin(client, app)
+    data = {
+        'name': 'Test Toy',
+        'description': 'A fun toy',
+        'price': '9.99',
+        'category': 'Otro',
+        'stock': '5'
+    }
+    response = client.post('/admin/toys/add', data=data, follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/admin/toys')
+    with app.app_context():
+        toy = Toy.query.filter_by(name='Test Toy').first()
+        assert toy is not None
+        assert toy.price == 9.99


### PR DESCRIPTION
## Summary
- Add `/admin/toys/add` route pointing to existing `add_toy` handler
- Redirect toy addition to inventory page
- Add unit test ensuring new endpoint persists toys and redirects

## Testing
- `pytest tests/unit/test_admin_add_toy_route.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68b0203d4880832788fba87c28e5a2f6