### PR TITLE
Add stock field to admin inventory form

### DIFF
--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -77,6 +77,10 @@
                     </select>
                 </div>
                 <div class="form-group">
+                    <label for="toyStock">Stock</label>
+                    <input type="number" id="toyStock" name="stock" min="0" required>
+                </div>
+                <div class="form-group">
                     <label for="toyImage">Imagen</label>
                     <input type="file" id="toyImage" name="image" accept="image/*" required>
                 </div>
@@ -198,6 +202,7 @@ function closeModal(modalId) {
 document.getElementById('addToyForm').onsubmit = async function(e) {
     e.preventDefault();
     const formData = new FormData(this);
+    formData.set('stock', document.getElementById('toyStock').value);
     try {
         const response = await fetch('/admin/toys/add', {
             method: 'POST',


### PR DESCRIPTION
## Summary
- add stock field to the admin inventory add-toy form
- include the stock value when submitting the form

## Testing
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68b029ebe0408327886502cc22b3f484