### PR TITLE
Sync age range categories in admin inventory

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -21,7 +21,11 @@ class ToyForm(FlaskForm):
         ('Electronicos', 'Electronicos'),
         ('Educativo', 'Educativo'),
         ('Muñecas', 'Muñecas'),
-        ('Otro', 'Otro')
+        ('Otro', 'Otro'),
+        ('0-3', '0-3 años'),
+        ('4-6', '4-6 años'),
+        ('7-9', '7-9 años'),
+        ('10+', '10+ años')
     ]
     category = SelectField('Categoría', choices=CATEGORIES, validators=[DataRequired()])
     stock = IntegerField('Cantidad en Stock', validators=[DataRequired(), NumberRange(min=0)])

--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -18,10 +18,9 @@
         <input type="text" id="toySearch" placeholder="Buscar juguetes..." class="search-input">
         <select id="categoryFilter" class="filter-select">
             <option value="all">Todas las categorías</option>
-            <option value="0-3">0-3 años</option>
-            <option value="4-6">4-6 años</option>
-            <option value="7-9">7-9 años</option>
-            <option value="10+">10+ años</option>
+            {% for value, label in toy_form.category.choices %}
+            <option value="{{ value }}">{{ label }}</option>
+            {% endfor %}
         </select>
     </div>
 
@@ -69,12 +68,7 @@
                 </div>
                 <div class="form-group">
                     <label for="toyCategory">Categoría de Edad</label>
-                    <select id="toyCategory" name="category" required>
-                        <option value="0-3">0-3 años</option>
-                        <option value="4-6">4-6 años</option>
-                        <option value="7-9">7-9 años</option>
-                        <option value="10+">10+ años</option>
-                    </select>
+                    {{ toy_form.category(id='toyCategory') }}
                 </div>
                 <div class="form-group">
                     <label for="toyImage">Imagen</label>


### PR DESCRIPTION
## Summary
- add age-range options to `ToyForm.CATEGORIES`
- render admin inventory category dropdowns from `toy_form.category`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app'; No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68b029eef6988327b32b6142b96b143e