### PR TITLE
Add stock field to admin inventory form

### DIFF
--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -68,6 +68,10 @@
                     <input type="number" id="toyPrice" name="price" step="0.01" required>
                 </div>
                 <div class="form-group">
+                    <label for="toyStock">Stock</label>
+                    <input type="number" id="toyStock" name="stock" min="0" required>
+                </div>
+                <div class="form-group">
                     <label for="toyCategory">Categoría de Edad</label>
                     {{ toy_form.category(id='toyCategory') }}
                 </div>
@@ -193,6 +197,7 @@ function closeModal(modalId) {
 document.getElementById('addToyForm').onsubmit = async function(e) {
     e.preventDefault();
     const formData = new FormData(this);
+    formData.set('stock', document.getElementById('toyStock').value);
     formData.set('csrf_token', document.querySelector('input[name="csrf_token"]').value);
     try {
         const response = await fetch('/admin/toys/add', {


### PR DESCRIPTION
## Summary
- ensure admin inventory add-toy modal includes stock field and submits value

## Testing
- `pytest` *(fails: 26 errors)*
- `pytest tests/unit`


------
https://chatgpt.com/codex/tasks/task_b_68b02bc034708327b975a6cd4d3fd39a