### PR TITLE
Use Flask static URLs for toy images

### DIFF
--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -29,7 +29,7 @@
         {% for toy in toys %}
         <div class="toy-card">
             <div class="toy-image">
-                <img src="{{ toy.image_url }}" alt="{{ toy.name }}">
+                <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
                 <div class="toy-actions">
                     <button class="action-btn edit" onclick="showEditToyModal('{{ toy.id }}')">
                         <i class="fas fa-edit"></i>

--- a/templates/advanced_search.html
+++ b/templates/advanced_search.html
@@ -477,8 +477,8 @@
                 {% for toy in results %}
                 <div class="col-md-6 col-lg-4">
                     <div class="toy-card">
-                        <img src="{{ toy.image_url or '/static/images/placeholder-toy.jpg' }}" 
-                             alt="{{ toy.name }}" 
+                        <img src="{{ url_for('static', filename=toy.image_url) if toy.image_url else url_for('static', filename='images/placeholder-toy.jpg') }}"
+                             alt="{{ toy.name }}"
                              class="toy-image">
                         <div class="toy-info">
                             <h6 class="toy-name">{{ toy.name }}</h6>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -14,7 +14,7 @@
                 {% for item in cart_items %}
                     <div class="cart-item" data-toy-id="{{ item.toy.id }}">
                         <div class="item-image">
-                            <img src="{{ item.toy.image_url }}" alt="{{ item.toy.name }}">
+                            <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
                         </div>
                         <div class="item-details">
                             <h3>{{ item.toy.name }}</h3>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -15,7 +15,7 @@
             {% for item in cart_items %}
                 <div class="checkout-item-card">
                     <div class="item-image">
-                        <img src="{{ item.toy.image_url }}" alt="{{ item.toy.name }}">
+                        <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
                     </div>
                     <div class="item-details">
                         <h3>{{ item.toy.name }}</h3>

--- a/templates/edit_toy.html
+++ b/templates/edit_toy.html
@@ -77,8 +77,8 @@
 
             <div class="current-image">
                 <p><strong>Imagen Actual:</strong></p>
-                <img src="{{ toy.image_url }}" 
-                     alt="{{ toy.name }}" 
+                <img src="{{ url_for('static', filename=toy.image_url) }}"
+                     alt="{{ toy.name }}"
                      class="preview-image">
             </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
         {% for toy in toys %}
             <div class="toy-card">
                 <div class="toy-image">
-                    <img src="{{ toy.image_url }}" alt="{{ toy.name }}">
+                    <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
                 </div>
                 <div class="toy-content">
                     <h3>{{ toy.name }}</h3>

--- a/templates/order_summary.html
+++ b/templates/order_summary.html
@@ -16,7 +16,7 @@
                 {% for item in order.items %}
                     <div class="order-item">
                         <div class="item-image">
-                            <img src="{{ item.toy.image_url }}" alt="{{ item.toy.name }}">
+                            <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
                         </div>
                         <div class="item-details">
                             <h3>{{ item.toy.name }}</h3>

--- a/templates/search.html
+++ b/templates/search.html
@@ -47,7 +47,7 @@
                 {% for toy in toys %}
                     <div class="toy-card">
                         <div class="toy-image">
-                            <img src="{{ toy.image_url }}" alt="{{ toy.name }}">
+                            <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
                         </div>
                         <div class="toy-content">
                             <h3>{{ toy.name }}</h3>


### PR DESCRIPTION
## Summary
- Switch all toy image tags in templates to use `url_for('static', ...)` for proper static asset handling.
- Keep database and upload logic saving images to `static/images/toys/` so new uploads render correctly across the site.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', requests)*

------
https://chatgpt.com/codex/tasks/task_b_68b02dcb7f5c83279197c4eac5f85168