### PR TITLE
Use url_for for toy image URLs

### DIFF
--- a/advanced_search.py
+++ b/advanced_search.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, or_, func, desc, asc
 # Agregar el directorio actual al path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from flask import url_for
 from app import create_app
 from app.extensions import db
 from app.models import Toy, Order, OrderItem
@@ -154,7 +155,7 @@ class AdvancedSearchEngine:
                     'price': float(toy.price),
                     'stock': toy.stock,
                     'category': toy.category,
-                    'image_url': toy.image_url,
+                    'image_url': url_for('static', filename=toy.image_url),
                     'is_on_sale': toy.price < toy.original_price if hasattr(toy, 'original_price') else False,
                     'popularity_score': self._calculate_popularity(toy.id)
                 }

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -501,7 +501,7 @@ def edit_toy(toy_id):
             'price': float(toy.price),
             'category': toy.category,
             'stock': toy.stock,
-            'image_url': toy.image_url
+            'image_url': url_for('static', filename=toy.image_url)
         }
         return jsonify(toy_data)
 
@@ -596,7 +596,7 @@ def toy_edit_new(toy_id):
                 'price': float(toy.price),
                 'category': toy.category,
                 'stock': toy.stock,
-                'image_url': toy.image_url
+                'image_url': url_for('static', filename=toy.image_url)
             }
         })
     

--- a/routes.py
+++ b/routes.py
@@ -317,7 +317,7 @@ def edit_toy(toy_id):
             'price': float(toy.price),
             'category': toy.category,
             'stock': toy.stock,
-            'image_url': toy.image_url
+            'image_url': url_for('static', filename=toy.image_url)
         }
         return jsonify(toy_data)
 

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -250,7 +250,7 @@ function initAdminPanel() {
                 if (data.image_url) {
                     imagePreview.innerHTML = `
                         <p>Imagen actual:</p>
-                        <img src="/static/${data.image_url}" alt="Imagen actual" style="max-width: 100px; max-height: 100px; object-fit: cover; border-radius: 8px;">
+                        <img src="${data.image_url}" alt="Imagen actual" style="max-width: 100px; max-height: 100px; object-fit: cover; border-radius: 8px;">
                     `;
                 } else {
                     imagePreview.innerHTML = '<p>Sin imagen actual</p>';
@@ -344,7 +344,7 @@ function editToy(toyId) {
         
         // Mostrar imagen actual si existe
         if (data.image_url) {
-            document.getElementById('currentImage').src = `/static/${data.image_url}`;
+            document.getElementById('currentImage').src = data.image_url;
             document.getElementById('currentImagePreview').style.display = 'block';
         }
         


### PR DESCRIPTION
## Summary
- Serve toy `image_url` fields using `url_for('static', ...)` in admin and main edit routes
- Build advanced search results with `url_for` and import it accordingly
- Update admin panel JS to use provided `image_url` without manual `/static/` prefix

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68b03041f90c8327a059a68bdbca6d77