### PR TITLE
Fix toy search filter dropdown and sorting

### DIFF
--- a/blueprints/shop.py
+++ b/blueprints/shop.py
@@ -133,7 +133,7 @@ def basic_search():
     """Búsqueda básica (fallback)"""
     query = request.args.get('query', '').strip()
     category = request.args.get('category', '')
-    sort = request.args.get('sort', 'created_at')
+    sort = request.args.get('sort', 'name')
     page = PaginationHelper.get_page_number()
     per_page = PaginationHelper.get_per_page(default=12)
     
@@ -160,7 +160,7 @@ def basic_search():
         toys_query = toys_query.order_by(Toy.price.asc())
     elif sort == 'price_desc':
         toys_query = toys_query.order_by(Toy.price.desc())
-    else:  # created_at por defecto
+    else:  # fallback
         toys_query = toys_query.order_by(Toy.created_at.desc())
     
     # Paginación
@@ -179,6 +179,8 @@ def basic_search():
         Toy.is_active == True,
         Toy.category.isnot(None)
     ).distinct().all()
+
+    category_list = sorted(cat[0] for cat in categories)
     
     return render_template(
         'search.html',
@@ -188,7 +190,7 @@ def basic_search():
         query=query,
         category=category,
         sort=sort,
-        categories=[cat[0] for cat in categories]
+        categories=category_list
     )
 
 @shop_bp.route('/search/suggestions')

--- a/templates/search.html
+++ b/templates/search.html
@@ -11,10 +11,10 @@
     <div class="search-form-container">
         <form method="GET" action="{{ url_for('shop.search') }}" class="search-form">
             <div class="search-input-group">
-                <input 
-                    type="text" 
-                    name="query" 
-                    value="{{ request.args.get('query', '') }}"
+                <input
+                    type="text"
+                    name="query"
+                    value="{{ query }}"
                     placeholder="Buscar juguetes..."
                     class="search-input"
                 >
@@ -26,15 +26,15 @@
             <div class="filter-group">
                 <select name="category" class="filter-select">
                     <option value="">Todas las categorías</option>
-                    <option value="Niña" {% if request.args.get('category') == 'Niña' %}selected{% endif %}>Niña</option>
-                    <option value="Niño" {% if request.args.get('category') == 'Niño' %}selected{% endif %}>Niño</option>
-                    <option value="Mixta" {% if request.args.get('category') == 'Mixta' %}selected{% endif %}>Mixta</option>
+                    {% for cat in categories %}
+                        <option value="{{ cat }}" {% if category == cat %}selected{% endif %}>{{ cat }}</option>
+                    {% endfor %}
                 </select>
-                
+
                 <select name="sort" class="filter-select">
-                    <option value="name" {% if request.args.get('sort') == 'name' %}selected{% endif %}>Nombre A-Z</option>
-                    <option value="price_low" {% if request.args.get('sort') == 'price_low' %}selected{% endif %}>Precio: Menor a Mayor</option>
-                    <option value="price_high" {% if request.args.get('sort') == 'price_high' %}selected{% endif %}>Precio: Mayor a Menor</option>
+                    <option value="name" {% if sort == 'name' %}selected{% endif %}>Nombre A-Z</option>
+                    <option value="price_asc" {% if sort == 'price_asc' %}selected{% endif %}>Precio: Menor a Mayor</option>
+                    <option value="price_desc" {% if sort == 'price_desc' %}selected{% endif %}>Precio: Mayor a Menor</option>
                 </select>
             </div>
         </form>


### PR DESCRIPTION
## Summary
- make basic toy search sort by name by default
- populate category dropdown from database and align sort values

## Testing
- `pytest tests/unit`
- `pytest -k search` *(fails: Interrupted: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68b03798a524832797bd5b3d055daa41