### PR TITLE
Fix toy search filter dropdown and sorting

### DIFF
--- a/blueprints/shop.py
+++ b/blueprints/shop.py
@@ -133,7 +133,7 @@ def basic_search():
     """Búsqueda básica (fallback)"""
     query = request.args.get('query', '').strip()
     category = request.args.get('category', '')
-    sort = request.args.get('sort', 'created_at')
+    sort = request.args.get('sort', 'name')
     page = PaginationHelper.get_page_number()
     per_page = PaginationHelper.get_per_page(default=12)
     
@@ -160,7 +160,7 @@ def basic_search():
         toys_query = toys_query.order_by(Toy.price.asc())
     elif sort == 'price_desc':
         toys_query = toys_query.order_by(Toy.price.desc())
-    else:  # created_at por defecto
+    else:  # fallback
         toys_query = toys_query.order_by(Toy.created_at.desc())
     
     # Paginación
@@ -179,6 +179,8 @@ def basic_search():
         Toy.is_active == True,
         Toy.category.isnot(None)
     ).distinct().all()
+
+    category_list = sorted(cat[0] for cat in categories)
     
     return render_template(
         'search.html',
@@ -188,7 +190,7 @@ def basic_search():
         query=query,
         category=category,
         sort=sort,
-        categories=[cat[0] for cat in categories]
+        categories=category_list
     )
 
 @shop_bp.route('/search/suggestions')

--- a/pagination_helpers.py
+++ b/pagination_helpers.py
@@ -29,9 +29,14 @@ class PaginationHelper:
     def build_pagination_urls(pagination, endpoint, **kwargs):
         """Construir URLs para navegación de páginas"""
         def build_url(page):
-            args = request.args.copy()
+            """Build a pagination URL preserving current query args"""
+            # start with current request args so existing filters persist
+            args = request.args.to_dict()
+            # allow explicit kwargs to override/augment request args
+            args.update(kwargs)
+            # set the desired page number
             args['page'] = page
-            return url_for(endpoint, **kwargs, **args)
+            return url_for(endpoint, **args)
         
         urls = {}
         

--- a/templates/search.html
+++ b/templates/search.html
@@ -11,10 +11,10 @@
     <div class="search-form-container">
         <form method="GET" action="{{ url_for('shop.search') }}" class="search-form">
             <div class="search-input-group">
-                <input 
-                    type="text" 
-                    name="query" 
-                    value="{{ request.args.get('query', '') }}"
+                <input
+                    type="text"
+                    name="query"
+                    value="{{ query }}"
                     placeholder="Buscar juguetes..."
                     class="search-input"
                 >
@@ -26,15 +26,15 @@
             <div class="filter-group">
                 <select name="category" class="filter-select">
                     <option value="">Todas las categorías</option>
-                    <option value="Niña" {% if request.args.get('category') == 'Niña' %}selected{% endif %}>Niña</option>
-                    <option value="Niño" {% if request.args.get('category') == 'Niño' %}selected{% endif %}>Niño</option>
-                    <option value="Mixta" {% if request.args.get('category') == 'Mixta' %}selected{% endif %}>Mixta</option>
+                    {% for cat in categories %}
+                        <option value="{{ cat }}" {% if category == cat %}selected{% endif %}>{{ cat }}</option>
+                    {% endfor %}
                 </select>
-                
+
                 <select name="sort" class="filter-select">
-                    <option value="name" {% if request.args.get('sort') == 'name' %}selected{% endif %}>Nombre A-Z</option>
-                    <option value="price_low" {% if request.args.get('sort') == 'price_low' %}selected{% endif %}>Precio: Menor a Mayor</option>
-                    <option value="price_high" {% if request.args.get('sort') == 'price_high' %}selected{% endif %}>Precio: Mayor a Menor</option>
+                    <option value="name" {% if sort == 'name' %}selected{% endif %}>Nombre A-Z</option>
+                    <option value="price_asc" {% if sort == 'price_asc' %}selected{% endif %}>Precio: Menor a Mayor</option>
+                    <option value="price_desc" {% if sort == 'price_desc' %}selected{% endif %}>Precio: Mayor a Menor</option>
                 </select>
             </div>
         </form>
@@ -47,7 +47,7 @@
                 {% for toy in toys %}
                     <div class="toy-card">
                         <div class="toy-image">
-                            <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
+                            <img src="{{ url_for('static', filename=toy.image_url) if toy.image_url else url_for('static', filename='images/placeholder-toy.jpg') }}" alt="{{ toy.name }}">
                         </div>
                         <div class="toy-content">
                             <h3>{{ toy.name }}</h3>


### PR DESCRIPTION
## Summary
- properly merge request parameters when building search pagination links to avoid server errors
- show a placeholder image in search results when a toy has no image URL

## Testing
- `pytest tests/unit`
- `pytest -k search` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_68b03798a524832797bd5b3d055daa41