### PR TITLE
Add CSV-based bulk toy upload

### DIFF
--- a/templates/bulk_upload_toys.html
+++ b/templates/bulk_upload_toys.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}Carga masiva de juguetes{% endblock %}
+
+{% block content %}
+<h1>Carga masiva de juguetes</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div>
+        <label for="csv_file">Archivo CSV</label>
+        <input type="file" name="csv_file" accept=".csv" required>
+    </div>
+    <div>
+        <label for="images">Imágenes de juguetes</label>
+        <input type="file" name="images" accept="image/*" multiple>
+        <p>Los nombres de archivo deben coincidir con el nombre del juguete en el CSV.</p>
+    </div>
+    <button type="submit">Subir juguetes</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow admins to bulk upload toys from a CSV with optional images
- add simple UI to upload CSV and image files for bulk creation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68bb85efb5f08327b7406499421bd31c