### PR TITLE
Add CSV-based bulk toy upload

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -440,6 +440,86 @@ def add_toy():
     
     return redirect(url_for('admin.toys_page'))
 
+@admin_bp.route('/bulk_upload_toys', methods=['GET', 'POST'])
+@login_required
+def bulk_upload_toys():
+    if not current_user.is_admin:
+        flash('Acceso denegado', 'error')
+        return redirect(url_for('shop.index'))
+
+    if request.method == 'POST':
+        csv_file = request.files.get('csv_file')
+        image_files = request.files.getlist('images')
+
+        if not csv_file:
+            flash('Se requiere un archivo CSV', 'error')
+            return redirect(url_for('admin.bulk_upload_toys'))
+
+        import csv
+        import re
+        from io import StringIO
+
+        csv_stream = StringIO(csv_file.stream.read().decode('utf-8-sig'))
+        reader = csv.DictReader(csv_stream)
+
+        image_map = {}
+        for img in image_files:
+            if img and img.filename:
+                filename = secure_filename(img.filename)
+                base = os.path.splitext(filename)[0].strip().lower().replace(' ', '_')
+                image_map[base] = (img, filename)
+
+        created = 0
+        for row in reader:
+            data = {k.strip().lower(): v.strip() for k, v in row.items() if k}
+            name = data.get('name')
+            if not name:
+                continue
+
+            try:
+                price = float(data.get('price', 0))
+            except ValueError:
+                price = 0.0
+            try:
+                stock = int(data.get('stock', 0))
+            except ValueError:
+                stock = 0
+
+            toy = Toy(
+                name=name,
+                description=data.get('description', ''),
+                price=price,
+                stock=stock,
+                age_range=data.get('age range') or data.get('age_range'),
+                gender_category=data.get('gender category') or data.get('gender_category'),
+                category=data.get('category')
+            )
+
+            base_name = os.path.splitext(secure_filename(name))[0].lower().replace(' ', '_')
+            if base_name in image_map:
+                img, filename = image_map[base_name]
+                upload_folder = os.path.join(current_app.static_folder, 'images', 'toys')
+                os.makedirs(upload_folder, exist_ok=True)
+                img.save(os.path.join(upload_folder, filename))
+                toy.image_url = f'images/toys/{filename}'
+
+            db.session.add(toy)
+            db.session.commit()
+
+            centers_str = data.get('center')
+            if centers_str:
+                centers = [c.strip().lower() for c in re.split(r'[;,]', centers_str) if c.strip()]
+                if 'all' not in centers:
+                    for center in centers:
+                        db.session.add(ToyCenterAvailability(toy_id=toy.id, center=center))
+                    db.session.commit()
+            created += 1
+
+        flash(f'{created} juguetes cargados exitosamente.', 'success')
+        return redirect(url_for('admin.toys_page'))
+
+    return render_template('bulk_upload_toys.html')
+
 @admin_bp.route('/edit_toy/<int:toy_id>', methods=['GET', 'POST'])
 @login_required
 def edit_toy(toy_id):

--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -10,6 +10,9 @@
             <button class="admin-btn" onclick="showAddToyModal()">
                 <i class="fas fa-plus"></i> Agregar Juguete
             </button>
+            <a class="admin-btn" href="{{ url_for('admin.bulk_upload_toys') }}">
+                <i class="fas fa-upload"></i> Carga masiva
+            </a>
         </div>
     </div>
 

--- a/templates/bulk_upload_toys.html
+++ b/templates/bulk_upload_toys.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}Carga masiva de juguetes{% endblock %}
+
+{% block content %}
+<h1>Carga masiva de juguetes</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div>
+        <label for="csv_file">Archivo CSV</label>
+        <input type="file" name="csv_file" accept=".csv" required>
+        <p style="font-size:0.9rem">Incluye las columnas: name, description, stock, price, age range, gender category, category y center. Usa "ALL" en center para todos los centros o separa múltiples centros con comas.</p>
+    </div>
+    <div>
+        <label for="images">Imágenes de juguetes</label>
+        <input type="file" name="images" accept="image/*" multiple>
+        <p>Los nombres de archivo deben coincidir con el nombre del juguete en el CSV.</p>
+    </div>
+    <button type="submit">Subir juguetes</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow admins to bulk upload toys from a CSV with optional images
- link bulk uploader from toy management and document CSV format
- handle `ALL` in center column for availability across all centers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'requests'; sqlite3 OperationalError)*

------
https://chatgpt.com/codex/tasks/task_b_68bb85efb5f08327b7406499421bd31c