### PR TITLE
Add CSV-based bulk toy upload

### DIFF
--- a/advanced_search.py
+++ b/advanced_search.py
@@ -175,7 +175,11 @@ class AdvancedSearchEngine:
                         Toy.description.ilike(f"%{term}%"),
                         Toy.category.ilike(f"%{term}%")
                     ]
-                    text_conditions.append(or_(*term_conditions))
+                    'image_url': (
+                        url_for('static', filename=toy.image_url)
+                        if toy.image_url
+                        else url_for('static', filename='images/toys/default_toy.png')
+                    ),
                 
                 if text_conditions:
                     query_obj = query_obj.filter(and_(*text_conditions))

--- a/app/models.py
+++ b/app/models.py
@@ -52,7 +52,7 @@ class Toy(db.Model):
     gender_category = db.Column(db.String(20), index=True)
     stock = db.Column(db.Integer, default=0)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
-    updated_at = db.Column(db.DateTime, onupdate=datetime.now)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
     deleted_at = db.Column(db.DateTime, nullable=True)
     is_active = db.Column(db.Boolean, default=True)
     

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -440,6 +440,103 @@ def add_toy():
     
     return redirect(url_for('admin.toys_page'))
 
+@admin_bp.route('/bulk_upload_toys', methods=['GET', 'POST'])
+@login_required
+def bulk_upload_toys():
+    """Cargar juguetes desde un CSV (sin imágenes)."""
+    if not current_user.is_admin:
+        flash('Acceso denegado', 'error')
+        return redirect(url_for('shop.index'))
+
+    if request.method == 'POST':
+        csv_file = request.files.get('csv_file')
+        if not csv_file:
+            flash('Se requiere un archivo CSV', 'error')
+            return redirect(url_for('admin.bulk_upload_toys'))
+
+        import csv
+        import re
+        from io import StringIO
+
+        try:
+            raw = csv_file.stream.read()
+            try:
+                text = raw.decode('utf-8-sig')
+            except UnicodeDecodeError:
+                text = raw.decode('latin-1')
+            csv_stream = StringIO(text)
+            reader = list(csv.DictReader(csv_stream))
+        except Exception as e:
+            flash(f'Error al procesar el CSV: {e}', 'error')
+            print(f'❌ Error procesando CSV: {e}', flush=True)
+            return redirect(url_for('admin.bulk_upload_toys'))
+        print(f'Iniciando carga masiva desde CSV: {len(reader)} filas', flush=True)
+
+        created = 0
+        errors = []
+        for idx, row in enumerate(reader, start=1):
+            data = {k.strip().lower(): (v or '').strip() for k, v in row.items() if k}
+            name = data.get('name')
+            if not name:
+                error_msg = f'❌ Fila {idx} sin nombre, omitida'
+                print(error_msg, flush=True)
+                errors.append(error_msg)
+                continue
+            print(f'[{idx}/{len(reader)}] Procesando: {name}', flush=True)
+            try:
+                try:
+                    price = float(data.get('price', 0) or 0)
+                except ValueError:
+                    price = 0.0
+                try:
+                    stock = int(data.get('stock', 0) or 0)
+                except ValueError:
+                    stock = 0
+
+                toy = Toy(
+                    name=name,
+                    description=data.get('description', ''),
+                    price=price,
+                    stock=stock,
+                    age_range=data.get('age range') or data.get('age_range'),
+                    gender_category=data.get('gender category') or data.get('gender_category'),
+                    category=data.get('category'),
+                    image_url=None,
+                    updated_at=datetime.now()
+                )
+
+                db.session.add(toy)
+                db.session.commit()
+
+                centers_str = data.get('center')
+                if centers_str:
+                    centers = [c.strip().lower() for c in re.split(r'[;,]', centers_str) if c.strip()]
+                    if 'all' in centers:
+                        for center, _ in AddUserForm.CENTERS:
+                            db.session.add(ToyCenterAvailability(toy_id=toy.id, center=center))
+                        db.session.commit()
+                    else:
+                        for center in centers:
+                            db.session.add(ToyCenterAvailability(toy_id=toy.id, center=center))
+                        db.session.commit()
+
+                created += 1
+                print(f'✔️ Fila {idx} procesada: {name}', flush=True)
+            except Exception as e:
+                db.session.rollback()
+                error_msg = f'❌ Error en fila {idx} ({name}): {e}'
+                print(error_msg, flush=True)
+                errors.append(error_msg)
+
+        for err in errors:
+            flash(err, 'error')
+        flash(f'{created} juguetes cargados exitosamente. {len(errors)} errores.',
+              'success' if not errors else 'warning')
+        print(f'Carga masiva completada: {created} éxitos, {len(errors)} errores', flush=True)
+        return redirect(url_for('admin.toys_page'))
+
+    return render_template('bulk_upload_toys.html')
+
 @admin_bp.route('/edit_toy/<int:toy_id>', methods=['GET', 'POST'])
 @login_required
 def edit_toy(toy_id):
@@ -518,7 +615,11 @@ def edit_toy(toy_id):
             'price': float(toy.price),
             'category': toy.category,
             'stock': toy.stock,
-            'image_url': url_for('static', filename=toy.image_url)
+            'image_url': (
+                url_for('static', filename=toy.image_url)
+                if toy.image_url
+                else url_for('static', filename='images/toys/default_toy.png')
+            )
         }
         return jsonify(toy_data)
 
@@ -681,7 +782,11 @@ def toy_edit_new(toy_id):
                 'price': float(toy.price),
                 'category': toy.category,
                 'stock': toy.stock,
-                'image_url': url_for('static', filename=toy.image_url)
+                'image_url': (
+                    url_for('static', filename=toy.image_url)
+                    if toy.image_url
+                    else url_for('static', filename='images/toys/default_toy.png')
+                )
             }
         })
     

--- a/blueprints/admin_full.tmp
+++ b/blueprints/admin_full.tmp
@@ -501,7 +501,11 @@ def edit_toy(toy_id):
             'price': float(toy.price),
             'category': toy.category,
             'stock': toy.stock,
-            'image_url': url_for('static', filename=toy.image_url)
+            'image_url': (
+                url_for('static', filename=toy.image_url)
+                if toy.image_url
+                else url_for('static', filename='images/toys/default_toy.png')
+            )
         }
         return jsonify(toy_data)
 
@@ -613,7 +617,11 @@ def toy_edit_new(toy_id):
                 'price': float(toy.price),
                 'category': toy.category,
                 'stock': toy.stock,
-                'image_url': url_for('static', filename=toy.image_url)
+                'image_url': (
+                    url_for('static', filename=toy.image_url)
+                    if toy.image_url
+                    else url_for('static', filename='images/toys/default_toy.png')
+                )
             }
         })
     

--- a/routes.py
+++ b/routes.py
@@ -317,7 +317,11 @@ def edit_toy(toy_id):
             'price': float(toy.price),
             'category': toy.category,
             'stock': toy.stock,
-            'image_url': url_for('static', filename=toy.image_url)
+            'image_url': (
+                url_for('static', filename=toy.image_url)
+                if toy.image_url
+                else url_for('static', filename='images/toys/default_toy.png')
+            )
         }
         return jsonify(toy_data)
 

--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -10,6 +10,9 @@
             <button class="admin-btn" onclick="showAddToyModal()">
                 <i class="fas fa-plus"></i> Agregar Juguete
             </button>
+            <a class="admin-btn" href="{{ url_for('admin.bulk_upload_toys') }}">
+                <i class="fas fa-upload"></i> Carga masiva
+            </a>
         </div>
     </div>
 
@@ -29,7 +32,7 @@
         {% for toy in toys %}
         <div class="toy-card" id="toy-{{ toy.id }}">
             <div class="toy-image">
-                <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
+                <img src="{{ url_for('static', filename=toy.image_url if toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ toy.name }}">
                 <div class="stock-controls">
                     <button class="stock-btn" onclick="adjustStock({{ toy.id }}, -1)">-</button>
                     <span class="stock-count" id="stock-{{ toy.id }}">{{ toy.stock }}</span>

--- a/templates/advanced_search.html
+++ b/templates/advanced_search.html
@@ -477,7 +477,7 @@
                 {% for toy in results %}
                 <div class="col-md-6 col-lg-4">
                     <div class="toy-card">
-                        <img src="{{ url_for('static', filename=toy.image_url) if toy.image_url else url_for('static', filename='images/placeholder-toy.jpg') }}"
+                        <img src="{{ url_for('static', filename=toy.image_url if toy.image_url else 'images/toys/default_toy.png') }}"
                              alt="{{ toy.name }}"
                              class="toy-image">
                         <div class="toy-info">

--- a/templates/bulk_upload_toys.html
+++ b/templates/bulk_upload_toys.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Carga masiva de juguetes{% endblock %}
+
+{% block content %}
+<h1>Carga masiva de juguetes</h1>
+<form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div>
+        <label for="csv_file">Archivo CSV</label>
+        <input type="file" name="csv_file" accept=".csv" required>
+        <p style="font-size:0.9rem">Incluye las columnas: name, description, stock, price, age range, gender category, category y center. Usa "ALL" en center para todos los centros o separa múltiples centros con comas. Las imágenes pueden añadirse luego al editar cada juguete.</p>
+    </div>
+    <button type="submit">Cargar CSV</button>
+</form>
+{% endblock %}
+

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -14,7 +14,7 @@
                 {% for item in cart_items %}
                     <div class="cart-item" data-toy-id="{{ item.toy.id }}">
                         <div class="item-image">
-                            <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
+                            <img src="{{ url_for('static', filename=item.toy.image_url if item.toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ item.toy.name }}">
                         </div>
                         <div class="item-details">
                             <h3>{{ item.toy.name }}</h3>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -15,7 +15,7 @@
             {% for item in cart_items %}
                 <div class="checkout-item-card">
                     <div class="item-image">
-                        <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
+                        <img src="{{ url_for('static', filename=item.toy.image_url if item.toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ item.toy.name }}">
                     </div>
                     <div class="item-details">
                         <h3>{{ item.toy.name }}</h3>

--- a/templates/edit_toy.html
+++ b/templates/edit_toy.html
@@ -77,7 +77,7 @@
 
             <div class="current-image">
                 <p><strong>Imagen Actual:</strong></p>
-                <img src="{{ url_for('static', filename=toy.image_url) }}"
+                <img src="{{ url_for('static', filename=toy.image_url if toy.image_url else 'images/toys/default_toy.png') }}"
                      alt="{{ toy.name }}"
                      class="preview-image">
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
         {% for toy in toys %}
             <div class="toy-card">
                 <div class="toy-image">
-                    <img src="{{ url_for('static', filename=toy.image_url) }}" alt="{{ toy.name }}">
+                    <img src="{{ url_for('static', filename=toy.image_url if toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ toy.name }}">
                 </div>
                 <div class="toy-content">
                     <h3>{{ toy.name }}</h3>

--- a/templates/order_summary.html
+++ b/templates/order_summary.html
@@ -16,7 +16,7 @@
                 {% for item in order.items %}
                     <div class="order-item">
                         <div class="item-image">
-                            <img src="{{ url_for('static', filename=item.toy.image_url) }}" alt="{{ item.toy.name }}">
+                            <img src="{{ url_for('static', filename=item.toy.image_url if item.toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ item.toy.name }}">
                         </div>
                         <div class="item-details">
                             <h3>{{ item.toy.name }}</h3>

--- a/templates/search.html
+++ b/templates/search.html
@@ -47,7 +47,7 @@
                 {% for toy in toys %}
                     <div class="toy-card">
                         <div class="toy-image">
-                            <img src="{{ url_for('static', filename=toy.image_url) if toy.image_url else url_for('static', filename='images/placeholder-toy.jpg') }}" alt="{{ toy.name }}">
+                            <img src="{{ url_for('static', filename=toy.image_url if toy.image_url else 'images/toys/default_toy.png') }}" alt="{{ toy.name }}">
                         </div>
                         <div class="toy-content">
                             <h3>{{ toy.name }}</h3>


### PR DESCRIPTION
## Summary
- allow admins to bulk upload toys from a CSV without requiring images
- handle missing toy images gracefully with a default placeholder and ensure `updated_at` timestamps are set

## Testing
- `pytest` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_b_68bb85efb5f08327b7406499421bd31c