### PR TITLE
Improve responsive styles and pagination layout

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -31,6 +31,16 @@
     --transition: all 0.3s ease;
 }
 
+/* Reset y utilidades globales para responsividad */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+img, video {
+    max-width: 100%;
+    height: auto;
+}
+
 /* Ajustes generales */
 body {
     font-family: var(--font-family);
@@ -45,6 +55,14 @@ body {
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+}
+
+/* Contenedor principal responsivo */
+.main-content {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem;
 }
 
 /* ============================
@@ -675,4 +693,126 @@ body {
 .desktop-nav a img.nav-icon,
 .mobile-nav a img.nav-icon {
   max-width: none;
+}
+
+/* ========================================
+   Paginacion responsiva
+   ======================================== */
+.pagination-nav {
+    display: flex;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.pagination {
+    display: flex;
+    gap: 0.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex-wrap: wrap;
+}
+
+.page-link {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 0.75rem 1rem;
+    border-radius: 8px;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 500;
+    font-size: 0.9rem;
+    box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3);
+    transition: all 0.3s ease;
+    min-width: 44px;
+    height: 44px;
+}
+
+.page-link:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+.page-item.active .page-link {
+    background: var(--primary-color);
+    box-shadow: 0 4px 15px rgba(16, 172, 132, 0.4);
+}
+
+.page-item.disabled .page-link {
+    background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%);
+    color: #6c757d;
+    box-shadow: none;
+    cursor: not-allowed;
+}
+
+.pagination-info {
+    text-align: center;
+    color: #6c757d;
+    margin-top: 0.5rem;
+}
+
+.pagination-per-page {
+    text-align: center;
+    margin-top: 0.75rem;
+}
+
+.per-page-selector {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.per-page-selector span,
+.per-page-selector a {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.85rem;
+    text-decoration: none;
+    box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3);
+    transition: all 0.3s ease;
+    min-width: 32px;
+    text-align: center;
+    display: inline-block;
+}
+
+.per-page-selector span.selected {
+    background: linear-gradient(135deg, #10ac84 0%, #1dd1a1 100%);
+    box-shadow: 0 3px 8px rgba(16, 172, 132, 0.3);
+    font-weight: 600;
+}
+
+.per-page-selector a:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+@media (max-width: 480px) {
+    .pagination {
+        gap: 0.25rem;
+    }
+
+    .page-link {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.8rem;
+        min-width: 36px;
+        height: 36px;
+    }
+
+    .per-page-selector {
+        gap: 0.25rem;
+    }
+
+    .per-page-selector span,
+    .per-page-selector a {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        min-width: 28px;
+    }
 }

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,124 +1,56 @@
-<!--
-Template de paginacion reutilizable para Tiendita ALOHA
-Uso: {% raw %}{% include 'pagination.html' with context %}{% endraw %}
-Variables requeridas: pagination, pagination_urls
--->
-
 {% if pagination and pagination.pages > 1 %}
-<nav aria-label="Navegacion de paginas" class="d-flex justify-content-center mt-4">
-    <ul class="pagination pagination-lg" style="display: flex; gap: 8px; list-style: none; padding: 0; margin: 0;">
-        <!-- Boton Primera Pagina -->
+<nav aria-label="Navegacion de paginas" class="pagination-nav">
+    <ul class="pagination">
         {% if pagination.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ pagination_urls.first }}" aria-label="Primera pagina"
-                   style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 8px; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 44px; height: 44px;"
-                   onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 6px 20px rgba(102, 126, 234, 0.4)';"
-                   onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 3px 10px rgba(102, 126, 234, 0.3)';">
-                    <span aria-hidden="true">&laquo;&laquo;</span>
-                </a>
+                <a class="page-link" href="{{ pagination_urls.first }}" aria-label="Primera pagina">&laquo;&laquo;</a>
             </li>
             <li class="page-item">
-                <a class="page-link" href="{{ pagination_urls.prev }}" aria-label="Pagina anterior"
-                   style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 8px; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 44px; height: 44px;"
-                   onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 6px 20px rgba(102, 126, 234, 0.4)';"
-                   onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 3px 10px rgba(102, 126, 234, 0.3)';">
-                    <span aria-hidden="true">&laquo;</span>
-                </a>
+                <a class="page-link" href="{{ pagination_urls.prev }}" aria-label="Pagina anterior">&laquo;</a>
             </li>
         {% else %}
-            <li class="page-item disabled">
-                <span class="page-link" 
-                      style="background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); color: #6c757d; padding: 12px 16px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; min-width: 44px; height: 44px; cursor: not-allowed;">&laquo;&laquo;</span>
-            </li>
-            <li class="page-item disabled">
-                <span class="page-link"
-                      style="background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); color: #6c757d; padding: 12px 16px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; min-width: 44px; height: 44px; cursor: not-allowed;">&laquo;</span>
-            </li>
+            <li class="page-item disabled"><span class="page-link">&laquo;&laquo;</span></li>
+            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
         {% endif %}
 
-        <!-- Numeros de paginas -->
         {% for page_info in pagination_urls.pages %}
             {% if page_info.current %}
-                <li class="page-item active" aria-current="page">
-                    <span class="page-link"
-                          style="background: linear-gradient(135deg, #10ac84 0%, #1dd1a1 100%); color: white; padding: 12px 16px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.9rem; box-shadow: 0 4px 15px rgba(16, 172, 132, 0.4); min-width: 44px; height: 44px;">
-                        {{ page_info.number }}
-                        <span class="sr-only">(pagina actual)</span>
-                    </span>
-                </li>
+                <li class="page-item active" aria-current="page"><span class="page-link">{{ page_info.number }}</span></li>
             {% else %}
-                <li class="page-item">
-                    <a class="page-link" href="{{ page_info.url }}"
-                       style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 8px; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 44px; height: 44px;"
-                       onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 6px 20px rgba(102, 126, 234, 0.4)';"
-                       onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 3px 10px rgba(102, 126, 234, 0.3)';">{{ page_info.number }}</a>
-                </li>
+                <li class="page-item"><a class="page-link" href="{{ page_info.url }}">{{ page_info.number }}</a></li>
             {% endif %}
         {% endfor %}
 
-        <!-- Boton Ultima Pagina -->
         {% if pagination.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ pagination_urls.next }}" aria-label="Pagina siguiente"
-                   style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 8px; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 44px; height: 44px;"
-                   onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 6px 20px rgba(102, 126, 234, 0.4)';"
-                   onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 3px 10px rgba(102, 126, 234, 0.3)';">
-                    <span aria-hidden="true">&raquo;</span>
-                </a>
-            </li>
-            <li class="page-item">
-                <a class="page-link" href="{{ pagination_urls.last }}" aria-label="Ultima pagina"
-                   style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 16px; border-radius: 8px; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; box-shadow: 0 3px 10px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 44px; height: 44px;"
-                   onmouseover="this.style.transform='translateY(-2px)'; this.style.boxShadow='0 6px 20px rgba(102, 126, 234, 0.4)';"
-                   onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 3px 10px rgba(102, 126, 234, 0.3)';">
-                    <span aria-hidden="true">&raquo;&raquo;</span>
-                </a>
-            </li>
+            <li class="page-item"><a class="page-link" href="{{ pagination_urls.next }}" aria-label="Pagina siguiente">&raquo;</a></li>
+            <li class="page-item"><a class="page-link" href="{{ pagination_urls.last }}" aria-label="Ultima pagina">&raquo;&raquo;</a></li>
         {% else %}
-            <li class="page-item disabled">
-                <span class="page-link"
-                      style="background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); color: #6c757d; padding: 12px 16px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; min-width: 44px; height: 44px; cursor: not-allowed;">&raquo;</span>
-            </li>
-            <li class="page-item disabled">
-                <span class="page-link"
-                      style="background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); color: #6c757d; padding: 12px 16px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; font-weight: 500; font-size: 0.9rem; min-width: 44px; height: 44px; cursor: not-allowed;">&raquo;&raquo;</span>
-            </li>
+            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            <li class="page-item disabled"><span class="page-link">&raquo;&raquo;</span></li>
         {% endif %}
     </ul>
 </nav>
-
-<!-- Informacion de paginacion -->
-<div class="text-center text-muted mt-2">
+<div class="pagination-info">
     <small>
-        Mostrando {{ pagination.per_page * (pagination.page - 1) + 1 }} - 
-        {{ pagination.per_page * (pagination.page - 1) + pagination.items|length }} 
+        Mostrando {{ pagination.per_page * (pagination.page - 1) + 1 }} -
+        {{ pagination.per_page * (pagination.page - 1) + pagination.items|length }}
         de {{ pagination.total }} resultados
-        {% if pagination.pages > 1 %}
-            (Pagina {{ pagination.page }} de {{ pagination.pages }})
-        {% endif %}
+        {% if pagination.pages > 1 %}(Pagina {{ pagination.page }} de {{ pagination.pages }}){% endif %}
     </small>
 </div>
-
-<!-- Selector de elementos por pagina -->
-<div class="text-center mt-3">
-    <div style="display: inline-flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: center;">
-        <span style="background: linear-gradient(135deg, #e9ecef 0%, #dee2e6 100%); color: #6c757d; padding: 8px 12px; border-radius: 6px; font-weight: 500; font-size: 0.85rem;">Por pagina:</span>
+<div class="pagination-per-page">
+    <div class="per-page-selector">
+        <span>Por pagina:</span>
         {% for per_page_option in [12, 24, 48] %}
             {% set current_per_page = request.args.get('per_page', '12')|int %}
             {% if per_page_option == current_per_page %}
-                <span style="background: linear-gradient(135deg, #10ac84 0%, #1dd1a1 100%); color: white; padding: 8px 12px; border-radius: 6px; font-weight: 600; font-size: 0.85rem; box-shadow: 0 3px 8px rgba(16, 172, 132, 0.3); min-width: 32px; text-align: center;">{{ per_page_option }}</span>
+                <span class="selected">{{ per_page_option }}</span>
             {% else %}
                 {% set args = request.args.copy() %}
                 {% set _ = args.update({'per_page': per_page_option, 'page': 1}) %}
-                <a href="{{ url_for(request.endpoint, **args.to_dict()) }}" 
-                   style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 8px 12px; border-radius: 6px; text-decoration: none; font-weight: 500; font-size: 0.85rem; box-shadow: 0 2px 6px rgba(102, 126, 234, 0.3); transition: all 0.3s ease; min-width: 32px; text-align: center; display: inline-block;"
-                   onmouseover="this.style.transform='translateY(-1px)'; this.style.boxShadow='0 4px 12px rgba(102, 126, 234, 0.4)';"
-                   onmouseout="this.style.transform='translateY(0)'; this.style.boxShadow='0 2px 6px rgba(102, 126, 234, 0.3)';">{{ per_page_option }}</a>
+                <a href="{{ url_for(request.endpoint, **args.to_dict()) }}">{{ per_page_option }}</a>
             {% endif %}
         {% endfor %}
     </div>
 </div>
 {% endif %}
-
-<!-- Estilos inline aplicados directamente para maxima especificidad y consistencia visual -->
-<!-- Todos los estilos estan aplicados inline en cada elemento para evitar conflictos de CSS -->


### PR DESCRIPTION
## Summary
- add global responsive utilities and main content container
- refactor pagination template and styles for mobile-friendly layout

## Testing
- `pytest` *(fails: sqlite3.OperationalError unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_b_68c47afc7b088327970726761a44c5c1