### PR TITLE
Increase mobile nav home icon size

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -128,10 +128,10 @@ body {
         display: block;
     }
     .mobile-nav a .nav-icon-inicio {
-        width: 24px !important;
-        height: 24px !important;
-        max-width: 24px;
-        max-height: 24px;
+        width: 28px !important;
+        height: 28px !important;
+        max-width: 28px;
+        max-height: 28px;
     }
 }
 
@@ -681,10 +681,10 @@ body {
 
 @media (max-width: 768px) {
   .mobile-nav a img.nav-icon.nav-icon-inicio {
-    width: 24px !important;
-    height: 24px !important;
-    max-width: 24px !important;
-    max-height: 24px !important;
+    width: 28px !important;
+    height: 28px !important;
+    max-width: 28px !important;
+    max-height: 28px !important;
     display: block; /* centers nicely inside the 48x48 circle */
   }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,8 +185,8 @@
                     img2.src = "{{ url_for('static', filename='images/logohome.png') }}";
                     img2.alt = 'Inicio';
                     img2.className = 'nav-icon nav-icon-inicio';  // both classes
-                    img2.style.width = '24px';                     // mobile fallback
-                    img2.style.height = '24px';
+                    img2.style.width = '28px';                     // mobile fallback
+                    img2.style.height = '28px';
                     mobileHome.appendChild(img2);
                 }
             } catch (e) {}


### PR DESCRIPTION
## Summary
- Enlarge mobile navigation home icon to 28px for better visibility and tap target.
- Adjust script fallback sizes to keep icon consistent across devices.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68c47f7e5a9883278d4c582f2067551c