### PR TITLE
Allow accented characters in toy data

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -21,7 +21,7 @@ class ToyForm(FlaskForm):
         ('Bloques', 'Bloques'),
         ('Vehículos', 'Vehículos'),
         ('Outdoor', 'Outdoor'),
-        ('Electronicos', 'Electronicos'),
+        ('Electrónicos', 'Electrónicos'),
         ('Educativo', 'Educativo'),
         ('Muñecas', 'Muñecas'),
         ('Otro', 'Otro'),
@@ -46,23 +46,23 @@ class ToyForm(FlaskForm):
         ('Juego', 'Juego'),
         ('Accesorio', 'Accesorio'),
         ('Bloques', 'Bloques'),
-        ('Vehiculos', 'Vehiculos'),
+        ('Vehículos', 'Vehículos'),
         ('Outdoor', 'Outdoor'),
-        ('Electronicos', 'Electronicos'),
+        ('Electrónicos', 'Electrónicos'),
         ('Educativo', 'Educativo'),
-        ('Munecas', 'Munecas'),
+        ('Muñecas', 'Muñecas'),
         ('Otro', 'Otro'),
     ]
     GENDER_CHOICES = [
-        ('Nina', 'Nina'),
-        ('Nino', 'Nino'),
+        ('Niña', 'Niña'),
+        ('Niño', 'Niño'),
         ('Mixto', 'Mixto'),
     ]
     AGE_CHOICES = [
-        ('0-3', '0-3 anos'),
-        ('4-6', '4-6 anos'),
-        ('7-9', '7-9 anos'),
-        ('10+', '10+ anos'),
+        ('0-3', '0-3 años'),
+        ('4-6', '4-6 años'),
+        ('7-9', '7-9 años'),
+        ('10+', '10+ años'),
     ]
     # Make category fields optional during edit operations
     toy_type = SelectField(

--- a/app/models.py
+++ b/app/models.py
@@ -44,16 +44,16 @@ class Toy(db.Model):
     __tablename__ = 'toy'
     
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), nullable=False, index=True)
-    description = db.Column(db.Text)
+    name = db.Column(db.Unicode(100), nullable=False, index=True)
+    description = db.Column(db.UnicodeText)
     price = db.Column(db.Float, nullable=False)
     image_url = db.Column(db.String(200))
     # Categoria de Juguete (tipo)
-    category = db.Column(db.String(50), index=True)
+    category = db.Column(db.Unicode(50), index=True)
     # Categoria de Edad (rango)
-    age_range = db.Column(db.String(20), index=True)
+    age_range = db.Column(db.Unicode(20), index=True)
     # Categoria de Genero
-    gender_category = db.Column(db.String(20), index=True)
+    gender_category = db.Column(db.Unicode(20), index=True)
     stock = db.Column(db.Integer, default=0)
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.now)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
@@ -114,7 +114,7 @@ class ToyCenterAvailability(db.Model):
         index=True,
     )
     # Mantener centros como texto para alinear con User.center
-    center = db.Column(db.String(64), nullable=False, index=True)
+    center = db.Column(db.Unicode(64), nullable=False, index=True)
 
     __table_args__ = (
         db.UniqueConstraint('toy_id', 'center', name='uq_toy_center'),

--- a/templates/admin/inventory.html
+++ b/templates/admin/inventory.html
@@ -20,7 +20,7 @@
     <div class="filter-section">
         <input type="text" id="toySearch" placeholder="Buscar juguetes..." class="search-input">
         <select id="categoryFilter" class="filter-select">
-            <option value="all">Todas las categorias</option>
+            <option value="all">Todas las categorías</option>
             {% for value, label in toy_form.toy_type.choices %}
             <option value="{{ value }}">{{ label }}</option>
             {% endfor %}
@@ -44,7 +44,7 @@
             </div>
             <div class="toy-info">
                 <h3>{{ toy.name }}</h3>
-                <p class="toy-price">{{ toy.price }} ALOHA Dolares</p>
+                <p class="toy-price">{{ toy.price }} ALOHA Dólares</p>
                 <p class="toy-category">{{ toy.category }}</p>
                 <p class="toy-description">{{ toy.description }}</p>
                 <div class="toy-centers">
@@ -76,11 +76,11 @@
                     <input type="text" id="toyName" name="name" required>
                 </div>
                 <div class="form-group">
-                    <label for="toyDescription">Descripcion</label>
+                    <label for="toyDescription">Descripción</label>
                     <textarea id="toyDescription" name="description" required></textarea>
                 </div>
                 <div class="form-group">
-                    <label for="toyPrice">Precio (ALOHA Dolares)</label>
+                    <label for="toyPrice">Precio (ALOHA Dólares)</label>
                     <input type="number" id="toyPrice" name="price" step="0.01" required>
                 </div>
                 <div class="form-group">
@@ -88,15 +88,15 @@
                     <input type="number" id="toyStock" name="stock" min="0" required>
                 </div>
                 <div class="form-group">
-                    <label for="toyCategory">Categoria de Edad</label>
+                    <label for="toyCategory">Categoría de Edad</label>
                     {{ toy_form.age_range(id='toyAge') }}
                 </div>
                 <div class="form-group">
-                    <label for="toyType">Categoria de Juguete</label>
+                    <label for="toyType">Categoría de Juguete</label>
                     {{ toy_form.toy_type(id='toyType') }}
                 </div>
                 <div class="form-group">
-                    <label for="toyGender">Categoria de Genero</label>
+                    <label for="toyGender">Categoría de Género</label>
                     {{ toy_form.gender(id='toyGender') }}
                 </div>
                 <div class="form-group">
@@ -450,7 +450,7 @@ document.getElementById('editToyForm').onsubmit = async function(e) {
             const stockEl = card.querySelector(`#stock-${toyId}`);
             if (nameEl) nameEl.textContent = form.get('name');
             if (descEl) descEl.textContent = form.get('description');
-            if (priceEl) priceEl.textContent = `${parseFloat(form.get('price')||0).toFixed(2)} ALOHA Dolares`;
+            if (priceEl) priceEl.textContent = `${parseFloat(form.get('price')||0).toFixed(2)} ALOHA Dólares`;
             if (stockEl) stockEl.textContent = form.get('stock');
             const catEl = card.querySelector('.toy-category');
             if (catEl) catEl.textContent = form.get('category') || '';

--- a/templates/advanced_search.html
+++ b/templates/advanced_search.html
@@ -300,7 +300,7 @@
                                    name="query" 
                                    id="searchInput"
                                    value="{{ current_query }}" 
-                                   placeholder="Buscar juguetes por nombre, categoria o descripcion..."
+                                   placeholder="Buscar juguetes por nombre, categoría o descripción..."
                                    autocomplete="off">
                             <div class="input-group-append">
                                 <button class="btn btn-primary search-btn" type="submit">
@@ -342,10 +342,10 @@
                     {% endif %}
                 </div>
                 
-                <!-- Filtro por Categoria -->
+                <!-- Filtro por Categoría -->
                 {% if facets.categories %}
                 <div class="filter-section">
-                    <div class="filter-title">Categorias</div>
+                    <div class="filter-title">Categorías</div>
                     {% for category in facets.categories %}
                     <div class="facet-item {% if category.active %}active{% endif %}" 
                          onclick="toggleFilter('category', '{{ category.value }}')">
@@ -579,7 +579,7 @@
                     <li>• Terminos de busqueda mas generales</li>
                     <li>• Verificar la ortografia</li>
                     <li>• Usar menos filtros</li>
-                    <li>• Explorar diferentes categorias</li>
+                    <li>• Explorar diferentes categorías</li>
                 </ul>
                 
                 {% if interface_data.popular_searches %}

--- a/templates/edit_toy.html
+++ b/templates/edit_toy.html
@@ -28,20 +28,20 @@
             <div class="form-group">
                 <label for="category">
                     <span class="icon">🏷️</span>
-                    Categoria
+                    Categoría
                 </label>
                 <select id="category" name="category" required class="category-select">
-                    <option value="" disabled>Selecciona una categoria</option>
-                    <option value="Nina" {% if toy.category == 'Nina' %}selected{% endif %}>👧 Juguetes de Nina</option>
-                    <option value="Nino" {% if toy.category == 'Nino' %}selected{% endif %}>👦 Juguetes de Nino</option>
-                    <option value="Mixta" {% if toy.category == 'Mixta' %}selected{% endif %}>👧👦 Juguetes Mixtos</option>
+                    <option value="" disabled>Selecciona una categoría</option>
+                    <option value="Niña" {% if toy.category == 'Niña' %}selected{% endif %}>👧 Juguetes de Niña</option>
+                    <option value="Niño" {% if toy.category == 'Niño' %}selected{% endif %}>👦 Juguetes de Niño</option>
+                    <option value="Mixto" {% if toy.category == 'Mixto' %}selected{% endif %}>👧👦 Juguetes Mixtos</option>
                 </select>
             </div>
 
             <div class="form-group">
                 <label for="description">
                     <span class="icon">📄</span>
-                    Descripcion
+                    Descripción
                 </label>
                 <textarea id="description" 
                           name="description" 

--- a/templates/inventory_dashboard.html
+++ b/templates/inventory_dashboard.html
@@ -194,11 +194,11 @@
                         <thead>
                             <tr>
                                 <th>Producto</th>
-                                <th>Categoria</th>
+                                <th>Categoría</th>
                                 <th>Stock Actual</th>
                                 <th>Precio</th>
                                 <th>Nivel de Alerta</th>
-                                <th>Ultima Actualizacion</th>
+                                <th>Última Actualización</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -287,12 +287,12 @@
     </div>
     {% endif %}
 
-    <!-- Categorias con Stock Bajo -->
+    <!-- Categorías con Stock Bajo -->
     {% if report.stats.categories_with_low_stock %}
     <div class="row">
         <div class="col-12">
             <div class="inventory-card">
-                <h4 class="mb-3">📊 Categorias Afectadas</h4>
+                <h4 class="mb-3">📊 Categorías Afectadas</h4>
                 <div class="row">
                     {% for category, count in report.stats.categories_with_low_stock.items() %}
                     <div class="col-md-4 mb-3">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -7,10 +7,10 @@
     <div class="profile-header">
         <h1>¡Hola {{ current_user.username }}! 👋</h1>
         <div class="balance-box">
-            <span class="balance-label">Mis ALOHA Dolares:</span>
+            <span class="balance-label">Mis ALOHA Dólares:</span>
             <span class="balance-amount">{{ current_user.balance|format_currency }}</span>
             <a href="#" onclick="showAddBalanceModal()" class="add-balance-button">
-                ➕ Agregar ALOHA Dolares
+                ➕ Agregar ALOHA Dólares
             </a>
         </div>
     </div>
@@ -127,7 +127,7 @@
 <!-- Modal para agregar balance -->
 <div id="addBalanceModal" class="modal">
     <div class="modal-content">
-        <h2>💰 Agregar ALOHA Dolares</h2>
+        <h2>💰 Agregar ALOHA Dólares</h2>
         <form action="{{ url_for('user.add_balance') }}" method="POST">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <div class="form-group">

--- a/templates/search.html
+++ b/templates/search.html
@@ -25,7 +25,7 @@
             
             <div class="filter-group">
                 <select name="category" class="filter-select">
-                    <option value="">Todas las categorias</option>
+                    <option value="">Todas las categorías</option>
                     {% for cat in categories %}
                         <option value="{{ cat }}" {% if category == cat %}selected{% endif %}>{{ cat }}</option>
                     {% endfor %}

--- a/tests/unit/test_admin_add_toy_route.py
+++ b/tests/unit/test_admin_add_toy_route.py
@@ -47,16 +47,20 @@ def login_as_admin(client, app):
 def test_add_toy_redirects_to_inventory(client, app):
     login_as_admin(client, app)
     data = {
-        'name': 'Test Toy',
-        'description': 'A fun toy',
+        'name': 'Muñeco Ñandú',
+        'description': 'Juguete con acentos: á, é, í, ó, ú y la letra ñ',
         'price': '9.99',
-        'category': 'Otro',
+        'toy_type': 'Otro',
+        'gender': 'Mixto',
+        'age_range': '4-6',
         'stock': '5'
     }
     response = client.post('/admin/toys/add', data=data, follow_redirects=False)
     assert response.status_code == 302
     assert response.headers['Location'].endswith('/admin/toys')
     with app.app_context():
-        toy = Toy.query.filter_by(name='Test Toy').first()
+        toy = Toy.query.filter_by(name='Muñeco Ñandú').first()
         assert toy is not None
         assert toy.price == 9.99
+        assert 'ñ' in toy.name
+        assert 'á' in toy.description


### PR DESCRIPTION
## Summary
- Store toy text fields using Unicode columns
- Accept and display accented Spanish options in toy form and admin templates
- Add regression test for toys with ñ and tildes

## Testing
- `pytest tests/unit/test_admin_add_toy_route.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests'; ModuleNotFoundError: No module named 'playwright'; sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e1f9f6708327b7af9654e93381b8