### PR TITLE
Allow admin user creation without emails

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -89,7 +89,11 @@ class ToyForm(FlaskForm):
 
 class AddUserForm(FlaskForm):
     username = StringField('Nombre de Usuario', validators=[DataRequired(), Length(min=3, max=64)])
-    email = StringField('Correo Electrónico', validators=[DataRequired(), Email(), Length(max=120)])
+    email = StringField(
+        'Correo Electrónico',
+        validators=[Optional(), Email(), Length(max=120)],
+        filters=[lambda value: value.strip() if value else None]
+    )
     password = PasswordField('Contraseña', validators=[DataRequired(), Length(min=6)])
     confirm_password = PasswordField('Confirmar Contraseña', validators=[DataRequired(), EqualTo('password', message='Las contraseñas deben coincidir.')])
     # Definir opciones de centros (ALOHA locations)
@@ -116,7 +120,11 @@ class AddUserForm(FlaskForm):
 
 class EditUserForm(FlaskForm):
     username = StringField('Nombre de Usuario', validators=[DataRequired(), Length(min=3, max=64)])
-    email = StringField('Correo Electrónico', validators=[DataRequired(), Email(), Length(max=120)])
+    email = StringField(
+        'Correo Electrónico',
+        validators=[Optional(), Email(), Length(max=120)],
+        filters=[lambda value: value.strip() if value else None]
+    )
     new_password = PasswordField('Nueva Contraseña (dejar en blanco para no cambiar)', validators=[Optional(), Length(min=6)])
     confirm_new_password = PasswordField('Confirmar Nueva Contraseña', validators=[EqualTo('new_password', message='Las nuevas contraseñas deben coincidir.')])
     center = SelectField('Centro/Sucursal', choices=AddUserForm.CENTERS, validators=[DataRequired()])

--- a/app/models.py
+++ b/app/models.py
@@ -9,7 +9,7 @@ class User(UserMixin, db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(64), unique=True, nullable=False, index=True)
-    email = db.Column(db.String(120), unique=True, nullable=False, index=True)
+    email = db.Column(db.String(120), unique=True, nullable=True, index=True)
     password_hash = db.Column(db.String(128), nullable=False)
     is_admin = db.Column(db.Boolean, default=False)
     # Force password reset on first login or when set by admin

--- a/create_db_tables.py
+++ b/create_db_tables.py
@@ -29,7 +29,7 @@ def create_tables():
     user_table = Table('user', metadata,
         Column('id', Integer, primary_key=True),
         Column('username', String(64), unique=True, nullable=False),
-        Column('email', String(120), unique=True, nullable=False),
+        Column('email', String(120), unique=True, nullable=True),
         Column('password_hash', String(128), nullable=False),
         Column('is_admin', Boolean, default=False),
         Column('balance', Float, default=0.0),

--- a/create_tables_manually.py
+++ b/create_tables_manually.py
@@ -21,7 +21,7 @@ users = Table(
     'user', metadata,
     Column('id', Integer, primary_key=True),
     Column('username', String(64), unique=True, nullable=False, index=True),
-    Column('email', String(120), unique=True, nullable=False, index=True),
+    Column('email', String(120), unique=True, nullable=True, index=True),
     Column('password_hash', String(128), nullable=False),
     Column('is_admin', Boolean, default=False),
     Column('balance', Float, default=0.0),

--- a/insert_test_data.py
+++ b/insert_test_data.py
@@ -35,7 +35,7 @@ except Exception as e:
         'user', metadata,
         Column('id', Integer, primary_key=True),
         Column('username', String(64), unique=True, nullable=False, index=True),
-        Column('email', String(120), unique=True, nullable=False, index=True),
+        Column('email', String(120), unique=True, nullable=True, index=True),
         Column('password_hash', String(128), nullable=False),
         Column('is_admin', Boolean, default=False),
         Column('balance', Float, default=0.0),

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -57,7 +57,7 @@
                         </div>
                         <div class="order-user">
                             <span class="user-name">👤 {{ order.user.username }}</span>
-                            <span class="user-email">✉️ {{ order.user.email }}</span>
+                            <span class="user-email">✉️ {{ order.user.email or 'Sin correo' }}</span>
                             <span class="user-center">🏪 {{ order.user.center }}</span>
                         </div>
                     </div>

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -90,9 +90,13 @@
                                     </div>
                                 </td>
                                 <td>
-                                    <a href="mailto:{{ user.email }}" class="user-email">
-                                        {{ user.email }}
-                                    </a>
+                                    {% if user.email %}
+                                        <a href="mailto:{{ user.email }}" class="user-email">
+                                            {{ user.email }}
+                                        </a>
+                                    {% else %}
+                                        <span class="user-email no-email">Sin correo</span>
+                                    {% endif %}
                                 </td>
                                 <td>{{ user.center or 'No especificado' }}</td>
                                 <td>{{ user.created_at.strftime('%d/%m/%Y') }}</td>
@@ -370,6 +374,12 @@
     text-decoration: none;
 }
 
+.user-email.no-email {
+    color: var(--muted-text, #6c757d);
+    cursor: default;
+    text-decoration: none;
+}
+
 .user-email:hover {
     text-decoration: underline;
 }
@@ -625,8 +635,8 @@ async function editBalance(userId, currentFormatted){
       <label>Nombre de Usuario
         <input class="text-input" type="text" name="username" required />
       </label>
-      <label>Correo Electrónico
-        <input class="text-input" type="email" name="email" required />
+      <label>Correo Electrónico (opcional)
+        <input class="text-input" type="email" name="email" />
       </label>
       <label>Centro/Sucursal
         <select class="text-input" name="center" required>

--- a/templates/inventory_dashboard.html
+++ b/templates/inventory_dashboard.html
@@ -347,8 +347,8 @@
                 <form id="alertForm">
                     <div class="form-group">
                         <label for="adminEmail">Email del Administrador:</label>
-                        <input type="email" class="form-control" id="adminEmail" 
-                               value="{{ current_user.email }}" required>
+                        <input type="email" class="form-control" id="adminEmail"
+                               value="{{ current_user.email or '' }}" required>
                     </div>
                     <div class="alert alert-info">
                         <strong>Se enviaran:</strong>


### PR DESCRIPTION
## Summary
- allow admins to submit the add/edit user forms without an email address and show a friendly placeholder when none is present
- make the `User.email` column nullable and update helper scripts/templates to accept optional emails
- guard admin flows that reference user emails so missing values no longer trigger database or rendering errors

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests'; sqlite3 OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_b_68c9707a2aa88327ab5af098cdb111ca