### PR TITLE
Use item-specific cart toast on mobile

### DIFF
--- a/blueprints/shop.py
+++ b/blueprints/shop.py
@@ -309,7 +309,7 @@ def add_to_cart():
         except Exception as e:
             # Fallback a sesiÃ³n
             is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
-            add_to_session_cart(toy_id, quantity, toy.name, show_flash_message=is_ajax)
+            add_to_session_cart(toy_id, quantity, toy.name, show_flash_message=not is_ajax)
             if is_ajax:
                 # Calcular cart_count para incluir en la respuesta
                 cart_count = 0
@@ -322,7 +322,7 @@ def add_to_cart():
                 })
     else:
         is_ajax = request.headers.get('X-Requested-With') == 'XMLHttpRequest'
-        add_to_session_cart(toy_id, quantity, toy.name, show_flash_message=is_ajax)
+        add_to_session_cart(toy_id, quantity, toy.name, show_flash_message=not is_ajax)
         if is_ajax:
             # Calcular cart_count para incluir en la respuesta
             cart_count = 0

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -177,7 +177,6 @@ function addToCart(toyId) {
         console.log('Respuesta recibida:', response.status);
         if (response.redirected) {
             // Si hay redireccion, probablemente fue exitoso
-            showToast('✨ ¡Producto agregado al carrito!', 'success');
             return { success: true };
         }
         return response.json();
@@ -185,7 +184,8 @@ function addToCart(toyId) {
     .then(data => {
         console.log('Datos recibidos:', data);
         if (data.success) {
-            showToast('✨ ¡Producto agregado al carrito!', 'success');
+            const successMessage = data.message || '✨ ¡Producto agregado al carrito!';
+            showToast(successMessage, 'success');
             // Actualizar el badge del carrito si existe cart_count en la respuesta
             if (data.cart_count !== undefined) {
                 updateCartBadge(data.cart_count);

--- a/templates/index.html
+++ b/templates/index.html
@@ -211,14 +211,14 @@ function addToCart(toyId) {
     .then(response => {
         if (response.redirected) {
             // Si hay redireccion, probablemente fue exitoso
-            showToast('✨ ¡Producto agregado al carrito!', 'success');
             return { success: true };
         }
         return response.json();
     })
     .then(data => {
         if (data.success) {
-            showToast('✨ ¡Producto agregado al carrito!', 'success');
+            const successMessage = data.message || '✨ ¡Producto agregado al carrito!';
+            showToast(successMessage, 'success');
         } else {
             showToast(data.message || '❌ Error al agregar al carrito', 'error');
         }


### PR DESCRIPTION
## Summary
- stop generating flash-based cart notifications for AJAX add-to-cart requests
- surface server-provided cart success messages immediately in the toast on mobile and desktop
- align inline add-to-cart handler with the main script messaging

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69248bea54848327aedbd3af5b828d7a)